### PR TITLE
Exercise 2.60

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Solving exercises from SICP with Clojure
 
 [![Clojure CI](https://github.com/SmetDenis/Clojure-Sicp/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/SmetDenis/Clojure-Sicp/actions/workflows/main.yml)
-![Progress](https://progress-bar.dev/105/?scale=356&title=Solved&width=500&suffix=)
+![Progress](https://progress-bar.dev/106/?scale=356&title=Solved&width=500&suffix=)
 
 SICP (Structure and Interpretation of Computer Programs) is the book of Harold Abelson and Gerald
 Jay Sussman on basics of computer science and software engineering.
@@ -42,7 +42,7 @@ Jay Sussman on basics of computer science and software engineering.
 
 ### Chapter 2 - Building Abstractions with Data
 
-![Progress](https://progress-bar.dev/59/?scale=97&title=Solved&width=500&suffix=)
+![Progress](https://progress-bar.dev/60/?scale=97&title=Solved&width=500&suffix=)
 
 * [2.1](https://sarabander.github.io/sicp/html/Chapter-2.xhtml#Chapter-2) Introduction to Data Abstraction - [Code in book](src/sicp/chapter_2/part_1/book_2_1.clj)
   * [2.1.1](https://sarabander.github.io/sicp/html/2_002e1.xhtml#g_t2_002e1_002e1) Example: Arithmetic Operations for Rational Numbers - [2.1](src/sicp/chapter_2/part_1/ex_2_01.clj)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Jay Sussman on basics of computer science and software engineering.
 * [2.3](https://sarabander.github.io/sicp/html/2_002e3.xhtml#g_t2_002e3) Symbolic Data - [Code in book](src/sicp/chapter_2/part_3/book_2_3.clj)
   * 2.3.1 Quotation - [2.53](src/sicp/chapter_2/part_3/ex_2_53.clj), [2.54](src/sicp/chapter_2/part_3/ex_2_54.clj), [2.55](src/sicp/chapter_2/part_3/ex_2_55.clj)
   * 2.3.2 Example: Symbolic Differentiation - [2.56](src/sicp/chapter_2/part_3/ex_2_56.clj), [2.57](src/sicp/chapter_2/part_3/ex_2_57.clj), [2.58](src/sicp/chapter_2/part_3/ex_2_58.clj)
-  * 2.3.3 Example: Representing Sets - [2.59](src/sicp/chapter_2/part_3/ex_2_59.clj)
+  * 2.3.3 Example: Representing Sets - [2.59](src/sicp/chapter_2/part_3/ex_2_59.clj), [2.60](src/sicp/chapter_2/part_3/ex_2_60.clj)
   * 2.3.4 Example: Huffman Encoding Trees
 * 2.4 Multiple Representations for Abstract Data
   * 2.4.1 Representations for Complex Numbers

--- a/src/sicp/chapter_2/part_3/ex_2_60.clj
+++ b/src/sicp/chapter_2/part_3/ex_2_60.clj
@@ -1,0 +1,38 @@
+(ns sicp.chapter-2.part-3.ex-2-60)
+
+; Exercise 2.60
+;
+; We specified that a set would be represented as a list with no duplicates.
+; Now suppose we allow duplicates. For instance, the set {1,2,3}
+; could be represented as the list (2 3 2 1 3 2 2).
+;
+; Design procedures element-of-set?, adjoin-set, union-set, and intersection-set that
+; operate on this representation.
+;
+; How does the efficiency of each compare with the corresponding procedure for
+; the non-duplicate representation? Are there applications for which
+; you would use this representation in preference to the non-duplicate one?)
+
+; No change to element-of-set?
+(defn element-of-set? [x set]
+  (cond
+    (empty? set) false
+    (= x (first set)) true
+    :else (element-of-set? x (rest set))))
+
+; No checks for duplicates in adjoin-set. It has complexity O(n)
+(defn adjoin-set [x set]
+  (cons x set))
+
+; No checks for duplicates in intersection-set. No visible reasons
+(defn intersection-set [set1 set2]
+  (cond
+    (or (empty? set1) (empty? set2)) '()
+    (element-of-set? (first set1) set2)
+    (cons (first set1) (intersection-set (rest set1) set2))
+    :else (intersection-set (rest set1) set2)))
+
+; No checks for duplicates in union-set
+; Complexity is O(n) instede of O(n^2)
+(defn union-set [set1 set2]
+  (concat set1 set2))

--- a/test/sicp/chapter_2/part_3/ex_2_60_test.clj
+++ b/test/sicp/chapter_2/part_3/ex_2_60_test.clj
@@ -1,0 +1,26 @@
+(ns sicp.chapter-2.part-3.ex-2-60-test
+  (:require [clojure.test :refer [deftest is]]
+            [sicp.chapter-2.part-3.ex-2-60 :refer [adjoin-set
+                                                   element-of-set?
+                                                   intersection-set
+                                                   union-set]]))
+
+(deftest element-of-set?-test
+  (is (= false (element-of-set? 1 '())))
+  (is (= true (element-of-set? 1 '(1))))
+  (is (= true (element-of-set? 1 '(1 2)))))
+
+(deftest adjoin-set-test
+  (is (= '(1 2 3) (adjoin-set 1 '(2 3))))
+  (is (= '(1 1 2 3) (adjoin-set 1 '(1 2 3)))))
+
+(deftest intersection-set-test
+  (is (= '() (intersection-set '() '())))
+  (is (= '() (intersection-set '(1 2) '())))
+  (is (= '() (intersection-set '() '(1 2))))
+  (is (= '(1) (intersection-set '(1) '(1))))
+  (is (= '(1) (intersection-set '(1 2) '(1))))
+  (is (= '(1) (intersection-set '(1) '(1 2)))))
+
+(deftest union-set-test
+  (is (= '(1 2 3 6 1 2 3 4 5) (union-set '(1 2 3 6) '(1 2 3 4 5)))))


### PR DESCRIPTION
Introduced unit tests for set operations in exercise 2.60. New procedures element-of-set?, adjoin-set, union-set, and intersection-set were introduced. The README file was also updated to link to exercise 2.60. These new procedures allow duplicates in the sets and were designed to improve efficiency compared to the previous non-duplicate representation.