### PR TITLE
Add sorted sets handling functionality

### DIFF
--- a/src/sicp/chapter_2/part_3/book_2_3.clj
+++ b/src/sicp/chapter_2/part_3/book_2_3.clj
@@ -91,3 +91,16 @@
     (element-of-set? (first set1) set2)
     (cons (first set1) (intersection-set (rest set1) set2))
     :else (intersection-set (rest set1) set2)))
+
+(defn element-of-set-sorted? [x set]
+  (cond (empty? set) false
+        (= x (first set)) true
+        (< x (first set)) false
+        :else (element-of-set-sorted? x (rest set))))
+
+(defn intersection-set-sorted [set1 set2]
+  (cond (or (empty? set1) (empty? set2)) '()
+        :else (let [x1 (first set1) x2 (first set2)]
+                (cond (= x1 x2) (cons x1 (intersection-set-sorted (rest set1) (rest set2)))
+                      (< x1 x2) (intersection-set-sorted (rest set1) set2)
+                      :else (intersection-set-sorted set1 (rest set2))))))

--- a/test/sicp/chapter_2/part_3/book_2_3_test.clj
+++ b/test/sicp/chapter_2/part_3/book_2_3_test.clj
@@ -1,10 +1,12 @@
 (ns sicp.chapter-2.part-3.book-2-3-test
   (:require [clojure.test :refer [deftest is]]
-            [sicp.chapter-2.part-3.book-2-3 :refer [memq
+            [sicp.chapter-2.part-3.book-2-3 :refer [adjoin-set
                                                     deriv
+                                                    element-of-set-sorted?
                                                     element-of-set?
-                                                    adjoin-set
-                                                    intersection-set]]))
+                                                    intersection-set
+                                                    intersection-set-sorted
+                                                    memq]]))
 
 (comment "2.3")
 ; Symbolic Data ------------------------------------------------------------------------------------
@@ -24,7 +26,7 @@
   (is (= 1 (deriv '(+ x 3) 'x)))
   (is (= 'y (deriv '(* x y) 'x)))
   (is (= '(+ (* x y) (* y (+ x 3)))
-          (deriv '(* (* x y) (+ x 3)) 'x))))
+         (deriv '(* (* x y) (+ x 3)) 'x))))
 
 (comment "2.3.3")
 ; Example: Representing Sets -----------------------------------------------------------------------
@@ -43,4 +45,18 @@
 (deftest intersection-set-test
   (is (= '() (intersection-set '(1 2) '(3 4))))
   (is (= '(3 4) (intersection-set '(3 4 5) '(3 4))))
-  (is (= '(4) (intersection-set '(4) '(3 4)))))
+  (is (= '(4) (intersection-set '(4) '(3 4))))
+  (is (= '(15 16 17 18 19) (intersection-set (range 20) (range 15 25)))))
+
+(deftest element-of-set-optimized?-test
+  (is (= true (element-of-set-sorted? 1 '(1 2 3))))
+  (is (= false (element-of-set-sorted? 1 '(2 3))))
+  (is (= false (element-of-set-sorted? 1 '())))
+  (is (= false (element-of-set-sorted? nil '())))
+  (is (= true (element-of-set-sorted? 100 (range 10000000))))) ; faster than element-of-set?
+
+(deftest intersection-set-sorted-test
+  (is (= '() (intersection-set-sorted '(1 2) '(3 4))))
+  (is (= '(3 4) (intersection-set-sorted '(3 4 5) '(3 4))))
+  (is (= '(4) (intersection-set-sorted '(4) '(3 4))))
+  (is (= '(15 16 17 18 19) (intersection-set-sorted (range 20) (range 15 25)))))


### PR DESCRIPTION
Extended the existing set operations to handle sorted sets. Added related functions, `element-of-set-sorted?` and `intersection-set-sorted`, to deal specifically with sorted sets, and included relevant tests. The new changes enable optimized set operations by making use of sorted set features.