### PR TITLE
Enhance set operations with tree representation

### DIFF
--- a/src/sicp/chapter_2/part_3/book_2_3.clj
+++ b/src/sicp/chapter_2/part_3/book_2_3.clj
@@ -1,5 +1,4 @@
-(ns sicp.chapter-2.part-3.book-2-3
-  (:require [clojure.set :as set]))
+(ns sicp.chapter-2.part-3.book-2-3)
 
 (comment "2.3")
 ; Symbolic Data ------------------------------------------------------------------------------------
@@ -92,6 +91,7 @@
     (cons (first set1) (intersection-set (rest set1) set2))
     :else (intersection-set (rest set1) set2)))
 
+; Sorted list for optimization
 (defn element-of-set-sorted? [x set]
   (cond (empty? set) false
         (= x (first set)) true
@@ -104,3 +104,25 @@
                 (cond (= x1 x2) (cons x1 (intersection-set-sorted (rest set1) (rest set2)))
                       (< x1 x2) (intersection-set-sorted (rest set1) set2)
                       :else (intersection-set-sorted set1 (rest set2))))))
+
+; List as tree
+(defn entry [tree] (first tree))
+(defn left-branch [tree] (second tree))
+(defn right-branch [tree] (nth tree 2))
+(defn make-tree [entry left right] (list entry left right))
+
+(defn element-of-set-tree? [x set]
+  (cond (empty? set) false
+        (= x (entry set)) true
+        (< x (entry set)) (element-of-set-tree? x (left-branch set))
+        :else (element-of-set-tree? x (right-branch set))))
+
+(defn adjoin-set-tree [x set]
+  (cond (empty? set) (make-tree x '() '())
+        (= x (entry set)) set
+        (< x (entry set)) (make-tree (entry set)
+                                     (adjoin-set-tree x (left-branch set))
+                                     (right-branch set))
+        :else (make-tree (entry set)
+                         (left-branch set)
+                         (adjoin-set-tree x (right-branch set)))))

--- a/test/sicp/chapter_2/part_3/book_2_3_test.clj
+++ b/test/sicp/chapter_2/part_3/book_2_3_test.clj
@@ -3,16 +3,21 @@
             [sicp.chapter-2.part-3.book-2-3 :refer [adjoin-set
                                                     deriv
                                                     element-of-set-sorted?
+                                                    element-of-set-tree?
                                                     element-of-set?
+                                                    entry
                                                     intersection-set
                                                     intersection-set-sorted
-                                                    memq]]))
+                                                    left-branch
+                                                    make-tree
+                                                    memq
+                                                    right-branch]]))
 
 (comment "2.3")
-; Symbolic Data ------------------------------------------------------------------------------------
+; symbolic data ------------------------------------------------------------------------------------
 
 (comment "2.3.1")
-; Quotation ----------------------------------------------------------------------------------------
+; quotation ----------------------------------------------------------------------------------------
 
 (deftest memq-test
   (is (= false (memq 'apple '(pear banana prune))))
@@ -20,7 +25,7 @@
   (is (= '(apple pear) (memq 'apple '(x (apple sauce) y apple pear)))))
 
 (comment "2.3.2")
-; Example: Symbolic Differentiation ----------------------------------------------------------------
+; example: symbolic differentiation ----------------------------------------------------------------
 
 (deftest deriv-test
   (is (= 1 (deriv '(+ x 3) 'x)))
@@ -29,7 +34,7 @@
          (deriv '(* (* x y) (+ x 3)) 'x))))
 
 (comment "2.3.3")
-; Example: Representing Sets -----------------------------------------------------------------------
+; example: representing sets -----------------------------------------------------------------------
 
 (deftest element-of-set?-test
   (is (= true (element-of-set? 1 '(1 2 3))))
@@ -60,3 +65,22 @@
   (is (= '(3 4) (intersection-set-sorted '(3 4 5) '(3 4))))
   (is (= '(4) (intersection-set-sorted '(4) '(3 4))))
   (is (= '(15 16 17 18 19) (intersection-set-sorted (range 20) (range 15 25)))))
+
+(deftest make-tree-test
+  (is (= '(1 () ()) (make-tree 1 '() '())))
+  (is (= '(1 (1 2 3) (4 5 6)) (make-tree 1 '(1 2 3) '(4 5 6)))))
+
+(deftest right-branch-test
+  (is (= '(3) (right-branch (make-tree 1 '(2) '(3))))))
+
+(deftest left-branch-test
+  (is (= '(2) (left-branch (make-tree 1 '(2) '(3))))))
+
+(deftest entry-test
+  (is (= 1 (entry (make-tree 1 '(2) '(3))))))
+
+(deftest element-of-set-tree?-test
+  (is (= true (element-of-set-tree? 2 (make-tree 2 '(1) '(3)))))
+  (is (= true (element-of-set-tree? 2 (make-tree 2 '(1) '(3)))))
+  (is (= true (element-of-set-tree? 3 (make-tree 2 '(1) '(3)))))
+  (is (= false (element-of-set-tree? 0 (make-tree 2 '(1) '(3))))))


### PR DESCRIPTION
This commit enhances set operations by implementing the use of a tree representation. It includes definitions of tree-related functions such as `entry`, `left-branch`, `right-branch` and `make-tree`. Additionally, the functions `element-of-set-tree?` and `adjoin-set-tree` have been introduced to perform set operations. Complementary tests have been added for these new functions.