### PR TITLE
Exercise 2.65

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Solving exercises from SICP with Clojure
 
 [![Clojure CI](https://github.com/SmetDenis/Clojure-Sicp/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/SmetDenis/Clojure-Sicp/actions/workflows/main.yml)
-![Progress](https://progress-bar.dev/110/?scale=356&title=Solved&width=500&suffix=)
+![Progress](https://progress-bar.dev/111/?scale=356&title=Solved&width=500&suffix=)
 
 SICP (Structure and Interpretation of Computer Programs) is the book of Harold Abelson and Gerald
 Jay Sussman on basics of computer science and software engineering.
@@ -42,7 +42,7 @@ Jay Sussman on basics of computer science and software engineering.
 
 ### Chapter 2 - Building Abstractions with Data
 
-![Progress](https://progress-bar.dev/64/?scale=97&title=Solved&width=500&suffix=)
+![Progress](https://progress-bar.dev/65/?scale=97&title=Solved&width=500&suffix=)
 
 * [2.1](https://sarabander.github.io/sicp/html/Chapter-2.xhtml#Chapter-2) Introduction to Data Abstraction - [Code in book](src/sicp/chapter_2/part_1/book_2_1.clj)
   * [2.1.1](https://sarabander.github.io/sicp/html/2_002e1.xhtml#g_t2_002e1_002e1) Example: Arithmetic Operations for Rational Numbers - [2.1](src/sicp/chapter_2/part_1/ex_2_01.clj)
@@ -57,7 +57,7 @@ Jay Sussman on basics of computer science and software engineering.
 * [2.3](https://sarabander.github.io/sicp/html/2_002e3.xhtml#g_t2_002e3) Symbolic Data - [Code in book](src/sicp/chapter_2/part_3/book_2_3.clj)
   * [2.3.1](https://sarabander.github.io/sicp/html/2_002e3.xhtml#g_t2_002e3_002e1) Quotation - [2.53](src/sicp/chapter_2/part_3/ex_2_53.clj), [2.54](src/sicp/chapter_2/part_3/ex_2_54.clj), [2.55](src/sicp/chapter_2/part_3/ex_2_55.clj)
   * [2.3.2](https://sarabander.github.io/sicp/html/2_002e3.xhtml#g_t2_002e3_002e2) Example: Symbolic Differentiation - [2.56](src/sicp/chapter_2/part_3/ex_2_56.clj), [2.57](src/sicp/chapter_2/part_3/ex_2_57.clj), [2.58](src/sicp/chapter_2/part_3/ex_2_58.clj)
-  * [2.3.3](https://sarabander.github.io/sicp/html/2_002e3.xhtml#g_t2_002e3_002e3) Example: Representing Sets - [2.59](src/sicp/chapter_2/part_3/ex_2_59.clj), [2.60](src/sicp/chapter_2/part_3/ex_2_60.clj), [2.61](src/sicp/chapter_2/part_3/ex_2_61.clj), [2.62](src/sicp/chapter_2/part_3/ex_2_62.clj), [2.63](src/sicp/chapter_2/part_3/ex_2_63.clj), [2.64](src/sicp/chapter_2/part_3/ex_2_64.clj)
+  * [2.3.3](https://sarabander.github.io/sicp/html/2_002e3.xhtml#g_t2_002e3_002e3) Example: Representing Sets - [2.59](src/sicp/chapter_2/part_3/ex_2_59.clj), [2.60](src/sicp/chapter_2/part_3/ex_2_60.clj), [2.61](src/sicp/chapter_2/part_3/ex_2_61.clj), [2.62](src/sicp/chapter_2/part_3/ex_2_62.clj), [2.63](src/sicp/chapter_2/part_3/ex_2_63.clj), [2.64](src/sicp/chapter_2/part_3/ex_2_64.clj), [2.65](src/sicp/chapter_2/part_3/ex_2_65.clj)
   * 2.3.4 Example: Huffman Encoding Trees
 * 2.4 Multiple Representations for Abstract Data
   * 2.4.1 Representations for Complex Numbers

--- a/src/sicp/chapter_2/part_3/ex_2_65.clj
+++ b/src/sicp/chapter_2/part_3/ex_2_65.clj
@@ -1,0 +1,55 @@
+(ns sicp.chapter-2.part-3.ex-2-65
+  (:require [sicp.chapter-2.part-3.book-2-3 :as b23]))
+
+; Exercise 2.65
+;
+; Use the results of Exercise 2.63 and Exercise 2.64 to give Θ(n)
+; implementations of union-set and intersection-set for sets implemented as (balanced) binary trees.
+
+(defn union-set-tree [tree1 tree2]
+  (cond
+    (empty? tree1) tree2
+    (empty? tree2) tree1
+    :else (let [tree1-entry        (b23/entry tree1)
+                tree1-left-branch  (b23/left-branch tree1)
+                tree1-right-branch (b23/right-branch tree1)
+                tree2-entry        (b23/entry tree2)
+                tree2-left-branch  (b23/left-branch tree2)
+                tree2-right-branch (b23/right-branch tree2)]
+            (cond
+              (= tree1-entry tree2-entry) (b23/make-tree tree1-entry
+                                                         (union-set-tree tree1-left-branch tree2-left-branch)
+                                                         (union-set-tree tree1-right-branch tree2-right-branch))
+              (< tree1-entry tree2-entry) (b23/make-tree tree2-entry
+                                                         (union-set-tree tree1 tree2-left-branch)
+                                                         tree2-right-branch)
+              :else (b23/make-tree tree1-entry
+                                   (union-set-tree tree1-left-branch tree2)
+                                   tree1-right-branch)))))
+
+(defn intersection-set-tree [tree1 tree2]
+  (cond
+    (empty? tree1) '()
+    (empty? tree2) '()
+    :else (let [tree1-entry        (b23/entry tree1)
+                tree1-left-branch  (b23/left-branch tree1)
+                tree1-right-branch (b23/right-branch tree1)
+                tree2-entry        (b23/entry tree2)
+                tree2-left-branch  (b23/left-branch tree2)
+                tree2-right-branch (b23/right-branch tree2)]
+            (cond
+              (= tree1-entry tree2-entry)
+              (b23/make-tree tree1-entry
+                             (intersection-set-tree tree1-left-branch tree2-left-branch)
+                             (intersection-set-tree tree1-right-branch tree2-right-branch))
+              (< tree1-entry tree2-entry)
+              (union-set-tree
+                (intersection-set-tree tree1-right-branch
+                                       (b23/make-tree tree2-entry '() tree2-right-branch))
+                (intersection-set-tree (b23/make-tree tree1-entry tree1-left-branch '())
+                                       tree2-left-branch))
+              :else (union-set-tree
+                      (intersection-set-tree (b23/make-tree tree1-entry '() tree1-right-branch)
+                                             tree2-right-branch)
+                      (intersection-set-tree tree1-left-branch
+                                             (b23/make-tree tree2-entry tree2-left-branch '())))))))

--- a/src/sicp/chapter_2/part_3/ex_2_65.clj
+++ b/src/sicp/chapter_2/part_3/ex_2_65.clj
@@ -10,46 +10,50 @@
   (cond
     (empty? tree1) tree2
     (empty? tree2) tree1
-    :else (let [tree1-entry        (b23/entry tree1)
-                tree1-left-branch  (b23/left-branch tree1)
-                tree1-right-branch (b23/right-branch tree1)
-                tree2-entry        (b23/entry tree2)
-                tree2-left-branch  (b23/left-branch tree2)
-                tree2-right-branch (b23/right-branch tree2)]
+    :else (let [tree1-entry (b23/entry tree1)
+                tree1-left  (b23/left-branch tree1)
+                tree1-right (b23/right-branch tree1)
+                tree2-entry (b23/entry tree2)
+                tree2-left  (b23/left-branch tree2)
+                tree2-right (b23/right-branch tree2)]
             (cond
               (= tree1-entry tree2-entry) (b23/make-tree tree1-entry
-                                                         (union-set-tree tree1-left-branch tree2-left-branch)
-                                                         (union-set-tree tree1-right-branch tree2-right-branch))
+                                                         (union-set-tree tree1-left tree2-left)
+                                                         (union-set-tree tree1-right tree2-right))
               (< tree1-entry tree2-entry) (b23/make-tree tree2-entry
-                                                         (union-set-tree tree1 tree2-left-branch)
-                                                         tree2-right-branch)
+                                                         (union-set-tree tree1 tree2-left)
+                                                         tree2-right)
               :else (b23/make-tree tree1-entry
-                                   (union-set-tree tree1-left-branch tree2)
-                                   tree1-right-branch)))))
+                                   (union-set-tree tree1-left tree2)
+                                   tree1-right)))))
 
 (defn intersection-set-tree [tree1 tree2]
   (cond
     (empty? tree1) '()
     (empty? tree2) '()
-    :else (let [tree1-entry        (b23/entry tree1)
-                tree1-left-branch  (b23/left-branch tree1)
-                tree1-right-branch (b23/right-branch tree1)
-                tree2-entry        (b23/entry tree2)
-                tree2-left-branch  (b23/left-branch tree2)
-                tree2-right-branch (b23/right-branch tree2)]
+    :else (let [tree1-entry (b23/entry tree1)
+                tree1-left  (b23/left-branch tree1)
+                tree1-right (b23/right-branch tree1)
+                tree2-entry (b23/entry tree2)
+                tree2-left  (b23/left-branch tree2)
+                tree2-right (b23/right-branch tree2)]
             (cond
-              (= tree1-entry tree2-entry)
-              (b23/make-tree tree1-entry
-                             (intersection-set-tree tree1-left-branch tree2-left-branch)
-                             (intersection-set-tree tree1-right-branch tree2-right-branch))
-              (< tree1-entry tree2-entry)
-              (union-set-tree
-                (intersection-set-tree tree1-right-branch
-                                       (b23/make-tree tree2-entry '() tree2-right-branch))
-                (intersection-set-tree (b23/make-tree tree1-entry tree1-left-branch '())
-                                       tree2-left-branch))
+              (= tree1-entry tree2-entry) (b23/make-tree tree1-entry
+                                                         (intersection-set-tree tree1-left tree2-left)
+                                                         (intersection-set-tree tree1-right tree2-right))
+              (< tree1-entry tree2-entry) (union-set-tree
+                                            (intersection-set-tree tree1-right
+                                                                   (b23/make-tree
+                                                                     tree2-entry
+                                                                     '()
+                                                                     tree2-right))
+                                            (intersection-set-tree (b23/make-tree
+                                                                     tree1-entry
+                                                                     tree1-left
+                                                                     '())
+                                                                   tree2-left))
               :else (union-set-tree
-                      (intersection-set-tree (b23/make-tree tree1-entry '() tree1-right-branch)
-                                             tree2-right-branch)
-                      (intersection-set-tree tree1-left-branch
-                                             (b23/make-tree tree2-entry tree2-left-branch '())))))))
+                      (intersection-set-tree (b23/make-tree tree1-entry '() tree1-right)
+                                             tree2-right)
+                      (intersection-set-tree tree1-left
+                                             (b23/make-tree tree2-entry tree2-left '())))))))

--- a/test/sicp/chapter_2/part_3/ex_2_65_test.clj
+++ b/test/sicp/chapter_2/part_3/ex_2_65_test.clj
@@ -1,0 +1,36 @@
+(ns sicp.chapter-2.part-3.ex-2-65-test
+  (:require [clojure.test :refer [deftest is]]
+            [sicp.chapter-2.part-3.ex-2-63 :refer [tree->list-2]]
+            [sicp.chapter-2.part-3.ex-2-64 :refer [list->tree]]
+            [sicp.chapter-2.part-3.ex-2-65 :refer [intersection-set-tree union-set-tree]]))
+
+(def tree1 (list->tree '(1 2 3)))
+(def tree2 (list->tree '(1 2 4)))
+(def tree3 (list->tree '(1 4 5)))
+
+(deftest union-set-tree-test
+  (is (= '(2
+            (1 () ())
+            (4
+              (3 () ())
+              ()))                                          ; Not balanced! It's fine...
+         (union-set-tree tree1 tree2)))
+  (is (= '(1 2 3 4)
+         (tree->list-2 (union-set-tree tree1 tree2))))
+  (is (= '(1 2 3 4)
+         (tree->list-2 (union-set-tree tree2 tree1))))
+  (is (= '(1 2 3 4 5)
+         (tree->list-2 (union-set-tree tree1 tree3))))
+  (is (= '(1 2 4 4 5)                                       ; Duplicate 4! Hm...?
+         (tree->list-2 (union-set-tree tree2 tree3)))))
+
+(deftest intersection-set-tree-test
+  (is (= '(2
+            (1
+              ()
+              ())
+            ())
+         (intersection-set-tree tree1 tree2)))
+  (is (= '(1 2) (tree->list-2 (intersection-set-tree tree1 tree2))))
+  (is (= '(1) (tree->list-2 (intersection-set-tree tree1 tree3))))
+  (is (= '(1 4) (tree->list-2 (intersection-set-tree tree2 tree3)))))


### PR DESCRIPTION
Added code and tests for Exercise 2.65 from the SICP book, including implementation of union-set and intersection-set functions for sets represented as balanced binary trees.