### PR TITLE
Exercise 2.66

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Solving exercises from SICP with Clojure
 
 [![Clojure CI](https://github.com/SmetDenis/Clojure-Sicp/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/SmetDenis/Clojure-Sicp/actions/workflows/main.yml)
-![Progress](https://progress-bar.dev/111/?scale=356&title=Solved&width=500&suffix=)
+![Progress](https://progress-bar.dev/112/?scale=356&title=Solved&width=500&suffix=)
 
 SICP (Structure and Interpretation of Computer Programs) is the book of Harold Abelson and Gerald
 Jay Sussman on basics of computer science and software engineering.
@@ -42,7 +42,7 @@ Jay Sussman on basics of computer science and software engineering.
 
 ### Chapter 2 - Building Abstractions with Data
 
-![Progress](https://progress-bar.dev/65/?scale=97&title=Solved&width=500&suffix=)
+![Progress](https://progress-bar.dev/66/?scale=97&title=Solved&width=500&suffix=)
 
 * [2.1](https://sarabander.github.io/sicp/html/Chapter-2.xhtml#Chapter-2) Introduction to Data Abstraction - [Code in book](src/sicp/chapter_2/part_1/book_2_1.clj)
   * [2.1.1](https://sarabander.github.io/sicp/html/2_002e1.xhtml#g_t2_002e1_002e1) Example: Arithmetic Operations for Rational Numbers - [2.1](src/sicp/chapter_2/part_1/ex_2_01.clj)
@@ -57,7 +57,7 @@ Jay Sussman on basics of computer science and software engineering.
 * [2.3](https://sarabander.github.io/sicp/html/2_002e3.xhtml#g_t2_002e3) Symbolic Data - [Code in book](src/sicp/chapter_2/part_3/book_2_3.clj)
   * [2.3.1](https://sarabander.github.io/sicp/html/2_002e3.xhtml#g_t2_002e3_002e1) Quotation - [2.53](src/sicp/chapter_2/part_3/ex_2_53.clj), [2.54](src/sicp/chapter_2/part_3/ex_2_54.clj), [2.55](src/sicp/chapter_2/part_3/ex_2_55.clj)
   * [2.3.2](https://sarabander.github.io/sicp/html/2_002e3.xhtml#g_t2_002e3_002e2) Example: Symbolic Differentiation - [2.56](src/sicp/chapter_2/part_3/ex_2_56.clj), [2.57](src/sicp/chapter_2/part_3/ex_2_57.clj), [2.58](src/sicp/chapter_2/part_3/ex_2_58.clj)
-  * [2.3.3](https://sarabander.github.io/sicp/html/2_002e3.xhtml#g_t2_002e3_002e3) Example: Representing Sets - [2.59](src/sicp/chapter_2/part_3/ex_2_59.clj), [2.60](src/sicp/chapter_2/part_3/ex_2_60.clj), [2.61](src/sicp/chapter_2/part_3/ex_2_61.clj), [2.62](src/sicp/chapter_2/part_3/ex_2_62.clj), [2.63](src/sicp/chapter_2/part_3/ex_2_63.clj), [2.64](src/sicp/chapter_2/part_3/ex_2_64.clj), [2.65](src/sicp/chapter_2/part_3/ex_2_65.clj)
+  * [2.3.3](https://sarabander.github.io/sicp/html/2_002e3.xhtml#g_t2_002e3_002e3) Example: Representing Sets - [2.59](src/sicp/chapter_2/part_3/ex_2_59.clj), [2.60](src/sicp/chapter_2/part_3/ex_2_60.clj), [2.61](src/sicp/chapter_2/part_3/ex_2_61.clj), [2.62](src/sicp/chapter_2/part_3/ex_2_62.clj), [2.63](src/sicp/chapter_2/part_3/ex_2_63.clj), [2.64](src/sicp/chapter_2/part_3/ex_2_64.clj), [2.65](src/sicp/chapter_2/part_3/ex_2_65.clj), [2.66](src/sicp/chapter_2/part_3/ex_2_66.clj)
   * 2.3.4 Example: Huffman Encoding Trees
 * 2.4 Multiple Representations for Abstract Data
   * 2.4.1 Representations for Complex Numbers

--- a/src/sicp/chapter_2/part_3/book_2_3.clj
+++ b/src/sicp/chapter_2/part_3/book_2_3.clj
@@ -135,3 +135,9 @@
         :else (make-tree (entry set)
                          (left-branch set)
                          (adjoin-set-tree x (right-branch set)))))
+
+(defn lookup [given-key set-of-records]
+  (cond
+    (empty? set-of-records) false
+    (= given-key (:key (first set-of-records))) (first set-of-records)
+    :else (lookup given-key (rest set-of-records))))

--- a/src/sicp/chapter_2/part_3/ex_2_66.clj
+++ b/src/sicp/chapter_2/part_3/ex_2_66.clj
@@ -1,0 +1,19 @@
+(ns sicp.chapter-2.part-3.ex-2-66
+  (:require [sicp.chapter-2.part-3.book-2-3 :as b23]))
+
+; Exercise 2.66
+;
+; Implement the lookup procedure for the case where the set of records is structured as
+; a binary tree, ordered by the numerical values of the keys.
+
+(defn lookup-tree [given-key set-of-records]
+  (if (empty? set-of-records)
+    false
+    (let [parent (b23/entry set-of-records)]
+      (cond
+        (nil? parent) false
+        (= given-key parent) parent
+        :else (lookup-tree given-key
+                           (if (< given-key parent)
+                             (b23/left-branch set-of-records)
+                             (b23/right-branch set-of-records)))))))

--- a/test/sicp/chapter_2/part_3/book_2_3_test.clj
+++ b/test/sicp/chapter_2/part_3/book_2_3_test.clj
@@ -9,6 +9,7 @@
                                                     intersection-set
                                                     intersection-set-sorted
                                                     left-branch
+                                                    lookup
                                                     make-tree
                                                     memq
                                                     right-branch]]))
@@ -87,3 +88,12 @@
   (is (= true (element-of-set-tree? 3 (make-tree 2 '(1) '(3)))))
   (is (= false (element-of-set-tree? 0 (make-tree 2 '(1) '(3)))))
   (is (= false (element-of-set-tree? 4 (make-tree 2 '(1) '(3))))))
+
+(deftest lookup-test
+  (let [records [{:key 1 :value "A"}
+                 {:key 2 :value "B"}
+                 {:key 3 :value "C"}]]
+    (is (= '{:key 1 :value "A"} (lookup 1 records)))
+    (is (= '{:key 2 :value "B"} (lookup 2 records)))
+    (is (= '{:key 3 :value "C"} (lookup 3 records)))
+    (is (= false (lookup 4 records)))))

--- a/test/sicp/chapter_2/part_3/ex_2_66_test.clj
+++ b/test/sicp/chapter_2/part_3/ex_2_66_test.clj
@@ -1,0 +1,12 @@
+(ns sicp.chapter-2.part-3.ex-2-66-test
+  (:require [clojure.test :refer [deftest is]]
+            [sicp.chapter-2.part-3.ex-2-64 :refer [list->tree]]
+            [sicp.chapter-2.part-3.ex-2-66 :refer [lookup-tree]]))
+
+(def tree (list->tree (range 10)))
+
+(deftest lookup-tree-test
+  (is (= false (lookup-tree 1 '())))
+  (is (= 1 (lookup-tree 1 tree)))
+  (is (= 5 (lookup-tree 5 tree)))
+  (is (= false (lookup-tree 10 tree))))


### PR DESCRIPTION
* Added a lookup function in the SICP chapter 2, part 3. This function designed to be applicable when the set of records is structured as a binary tree. Along with this function, corresponding tests have also been introduced to validate its correctness.
* Implemented the lookup procedure as described in exercise 2.66 of SICP Chapter 2, Part 3, for a record set structured as a binary tree. Updated the README.md file to reflect completion of this exercise and devised tests to ensure the correct functioning of the lookup procedure.