### PR TITLE
Refactor namespace naming in SICP exercises 

### DIFF
--- a/src/sicp/chapter_1/part_1/ex_1_01.clj
+++ b/src/sicp/chapter_1/part_1/ex_1_01.clj
@@ -1,4 +1,4 @@
-(ns sicp.chapter-1.part_1.ex-1-01)
+(ns sicp.chapter-1.part-1.ex-1-01)
 
 ; Exercise 1.1
 ; Below is a sequence of expressions.

--- a/src/sicp/chapter_1/part_1/ex_1_02.clj
+++ b/src/sicp/chapter_1/part_1/ex_1_02.clj
@@ -1,4 +1,4 @@
-(ns sicp.chapter_1.part_1.ex-1-02)
+(ns sicp.chapter-1.part-1.ex-1-02)
 
 ; Exercise 1.2
 ; Translate the following expression into prefix form:

--- a/src/sicp/chapter_1/part_1/ex_1_03.clj
+++ b/src/sicp/chapter_1/part_1/ex_1_03.clj
@@ -1,4 +1,4 @@
-(ns sicp.chapter-1.part_1.ex-1-03)
+(ns sicp.chapter-1.part-1.ex-1-03)
 
 ; Exercise 1.3
 ; Define a procedure that takes three numbers as arguments and returns the sum of the squares of the two

--- a/src/sicp/chapter_1/part_1/ex_1_04.clj
+++ b/src/sicp/chapter_1/part_1/ex_1_04.clj
@@ -1,4 +1,4 @@
-(ns sicp.chapter-1.part_1.ex-1-04)
+(ns sicp.chapter-1.part-1.ex-1-04)
 
 ; Exercise 1.4
 ; Observe that our model of evaluation allows for combinations whose operators are compound expressions.

--- a/src/sicp/chapter_1/part_1/ex_1_05.clj
+++ b/src/sicp/chapter_1/part_1/ex_1_05.clj
@@ -1,4 +1,4 @@
-(ns sicp.chapter-1.part_1.ex-1-05)
+(ns sicp.chapter-1.part-1.ex-1-05)
 
 ; Exercise 1.5
 ; Ben Bitdiddle has invented a test to determine whether the interpreter he is faced with is

--- a/src/sicp/chapter_1/part_1/ex_1_06.clj
+++ b/src/sicp/chapter_1/part_1/ex_1_06.clj
@@ -1,4 +1,4 @@
-(ns sicp.chapter-1.part_1.ex-1-06
+(ns sicp.chapter-1.part-1.ex-1-06
   (:require [sicp.chapter-1.part-1.book-1-1 :as b11]))
 
 ; Exercise 1.6

--- a/src/sicp/chapter_1/part_1/ex_1_07.clj
+++ b/src/sicp/chapter_1/part_1/ex_1_07.clj
@@ -1,4 +1,4 @@
-(ns sicp.chapter-1.part_1.ex-1-07
+(ns sicp.chapter-1.part-1.ex-1-07
   (:require [sicp.chapter-1.part-1.book-1-1 :as b11]))
 
 ; Exercise 1.7

--- a/src/sicp/chapter_1/part_1/ex_1_08.clj
+++ b/src/sicp/chapter_1/part_1/ex_1_08.clj
@@ -1,4 +1,4 @@
-(ns sicp.chapter-1.part_1.ex-1-08
+(ns sicp.chapter-1.part-1.ex-1-08
   (:require [sicp.chapter-1.part-1.book-1-1 :as b11]))
 
 ; Exercise 1.8

--- a/src/sicp/chapter_1/part_2/ex_1_09.clj
+++ b/src/sicp/chapter_1/part_2/ex_1_09.clj
@@ -1,4 +1,4 @@
-(ns sicp.chapter-1.part_2.ex-1-09)
+(ns sicp.chapter-1.part-2.ex-1-09)
 
 ; Exercise 1.9
 ; Each of the following two procedures defines a method for adding two positive integers

--- a/src/sicp/chapter_1/part_2/ex_1_10.clj
+++ b/src/sicp/chapter_1/part_2/ex_1_10.clj
@@ -1,4 +1,4 @@
-(ns sicp.chapter-1.part_2.ex-1-10)
+(ns sicp.chapter-1.part-2.ex-1-10)
 
 ; Exercise 1.10
 ; The following procedure computes a mathematical function called Ackermann’s function.

--- a/src/sicp/chapter_1/part_2/ex_1_11.clj
+++ b/src/sicp/chapter_1/part_2/ex_1_11.clj
@@ -1,4 +1,4 @@
-(ns sicp.chapter-1.part_2.ex-1-11)
+(ns sicp.chapter-1.part-2.ex-1-11)
 
 ; Exercise 1.11
 ; A function f is defined by the rule that f(n)=n

--- a/src/sicp/chapter_1/part_2/ex_1_12.clj
+++ b/src/sicp/chapter_1/part_2/ex_1_12.clj
@@ -1,4 +1,4 @@
-(ns sicp.chapter-1.part_2.ex-1-12)
+(ns sicp.chapter-1.part-2.ex-1-12)
 
 ; Exercise 1.12
 ; The following pattern of numbers is called Pascal’s triangle.

--- a/src/sicp/chapter_1/part_2/ex_1_13.clj
+++ b/src/sicp/chapter_1/part_2/ex_1_13.clj
@@ -1,4 +1,4 @@
-(ns sicp.chapter-1.part_2.ex-1-13)
+(ns sicp.chapter-1.part-2.ex-1-13)
 
 ; Exercise 1.13
 ; Prove that Fib(n) is the closest integer to φn/5⎯√, where φ=(1+5⎯√)/2.

--- a/src/sicp/chapter_1/part_2/ex_1_14.clj
+++ b/src/sicp/chapter_1/part_2/ex_1_14.clj
@@ -1,4 +1,4 @@
-(ns sicp.chapter-1.part_2.ex-1-14
+(ns sicp.chapter-1.part-2.ex-1-14
   (:require [sicp.chapter-1.part-2.book-1-2 :as b12]))
 
 ; Exercise 1.14

--- a/src/sicp/chapter_1/part_2/ex_1_15.clj
+++ b/src/sicp/chapter_1/part_2/ex_1_15.clj
@@ -1,4 +1,4 @@
-(ns sicp.chapter-1.part_2.ex_1_15)
+(ns sicp.chapter-1.part-2.ex-1-15)
 
 ; Exercise 1.15
 ; The sine of an angle (specified in radians) can be computed by making use of the approximation sinx≈x

--- a/src/sicp/chapter_1/part_2/ex_1_16.clj
+++ b/src/sicp/chapter_1/part_2/ex_1_16.clj
@@ -1,4 +1,4 @@
-(ns sicp.chapter-1.part_2.ex-1-16)
+(ns sicp.chapter-1.part-2.ex-1-16)
 
 ; Exercise 1.16
 ; Design a procedure that evolves an iterative exponentiation process

--- a/src/sicp/chapter_1/part_2/ex_1_17.clj
+++ b/src/sicp/chapter_1/part_2/ex_1_17.clj
@@ -1,4 +1,4 @@
-(ns sicp.chapter-1.part_2.ex-1-17)
+(ns sicp.chapter-1.part-2.ex-1-17)
 
 ; Exercise 1.17
 ; The exponentiation algorithms in this section are based on performing exponentiation by means of repeated

--- a/src/sicp/chapter_1/part_2/ex_1_18.clj
+++ b/src/sicp/chapter_1/part_2/ex_1_18.clj
@@ -1,5 +1,5 @@
-(ns sicp.chapter-1.part_2.ex-1-18
-  (:require [sicp.chapter-1.part_2.ex-1-16 :refer [expt]]))
+(ns sicp.chapter-1.part-2.ex-1-18
+  (:require [sicp.chapter-1.part-2.ex-1-16 :refer [expt]]))
 
 ; Exercise 1.18
 ; Using the results of Exercise 1.16 and Exercise 1.17, devise a procedure that generates an iterative

--- a/src/sicp/chapter_1/part_2/ex_1_19.clj
+++ b/src/sicp/chapter_1/part_2/ex_1_19.clj
@@ -1,4 +1,4 @@
-(ns sicp.chapter-1.part_2.ex-1-19)
+(ns sicp.chapter-1.part-2.ex-1-19)
 
 ; Exercise 1.19.
 ;

--- a/src/sicp/chapter_1/part_2/ex_1_20.clj
+++ b/src/sicp/chapter_1/part_2/ex_1_20.clj
@@ -1,4 +1,4 @@
-(ns sicp.chapter-1.part_2.ex-1-20)
+(ns sicp.chapter-1.part-2.ex-1-20)
 
 ; Exercise 1.20
 ; The process that a procedure generates is of course dependent on the rules used by the interpreter.

--- a/src/sicp/chapter_1/part_2/ex_1_21.clj
+++ b/src/sicp/chapter_1/part_2/ex_1_21.clj
@@ -1,4 +1,4 @@
-(ns sicp.chapter-1.part_2.ex-1-21
+(ns sicp.chapter-1.part-2.ex-1-21
   (:require [sicp.misc :as m]))
 
 ; Exercise 1.21

--- a/src/sicp/chapter_1/part_2/ex_1_22.clj
+++ b/src/sicp/chapter_1/part_2/ex_1_22.clj
@@ -1,4 +1,4 @@
-(ns sicp.chapter-1.part_2.ex-1-22)
+(ns sicp.chapter-1.part-2.ex-1-22)
 
 ; Exercise 1.22
 ; Most Lisp implementations include a primitive called runtime that returns an integer that specifies

--- a/src/sicp/chapter_1/part_2/ex_1_23.clj
+++ b/src/sicp/chapter_1/part_2/ex_1_23.clj
@@ -1,4 +1,4 @@
-(ns sicp.chapter-1.part_2.ex-1-23
+(ns sicp.chapter-1.part-2.ex-1-23
   (:require [sicp.misc :as m]))
 
 ; Exercise 1.23

--- a/src/sicp/chapter_1/part_2/ex_1_24.clj
+++ b/src/sicp/chapter_1/part_2/ex_1_24.clj
@@ -1,4 +1,4 @@
-(ns sicp.chapter-1.part_2.ex-1-24)
+(ns sicp.chapter-1.part-2.ex-1-24)
 
 ; Exercise 1.24
 ; Modify the timed-prime-test procedure of Exercise 1.22 to use fast-prime? (the Fermat method),

--- a/test/sicp/chapter_1/part_1/ex_1_3_test.clj
+++ b/test/sicp/chapter_1/part_1/ex_1_3_test.clj
@@ -1,6 +1,6 @@
-(ns sicp.chapter-1.part_1.ex-1-3-test
+(ns sicp.chapter-1.part-1.ex-1-3-test
   (:require [clojure.test :refer [deftest is]]
-            [sicp.chapter-1.part_1.ex-1-03 :refer [sum-larger-numbers-square]]))
+            [sicp.chapter-1.part-1.ex-1-03 :refer [sum-larger-numbers-square]]))
 
 (deftest sum-larger-numbers-square-test
   (is (= 2 (sum-larger-numbers-square 1 1 1)))

--- a/test/sicp/chapter_1/part_1/ex_1_4_test.clj
+++ b/test/sicp/chapter_1/part_1/ex_1_4_test.clj
@@ -1,6 +1,6 @@
-(ns sicp.chapter-1.part_1.ex-1-4-test
+(ns sicp.chapter-1.part-1.ex-1-4-test
   (:require [clojure.test :refer [deftest is]]
-            [sicp.chapter-1.part_1.ex-1-04 :refer [a-plus-abs-b]]))
+            [sicp.chapter-1.part-1.ex-1-04 :refer [a-plus-abs-b]]))
 
 (deftest a-plus-abs-b-test
   (is (= 2 (a-plus-abs-b 1 1)))

--- a/test/sicp/chapter_1/part_1/ex_1_5_test.clj
+++ b/test/sicp/chapter_1/part_1/ex_1_5_test.clj
@@ -1,6 +1,6 @@
-(ns sicp.chapter-1.part_1.ex-1-5-test
+(ns sicp.chapter-1.part-1.ex-1-5-test
   (:require [clojure.test :refer [deftest is]]
-            [sicp.chapter-1.part_1.ex-1-05 :refer [p test_1_5]]))
+            [sicp.chapter-1.part-1.ex-1-05 :refer [p test_1_5]]))
 
 (deftest test_1_5-test
   ; Normal: Operand "p" will not be evaluated until it's needed by some primitive operation. So result is 0.

--- a/test/sicp/chapter_1/part_1/ex_1_6_test.clj
+++ b/test/sicp/chapter_1/part_1/ex_1_6_test.clj
@@ -1,7 +1,7 @@
-(ns sicp.chapter-1.part_1.ex-1-6-test
+(ns sicp.chapter-1.part-1.ex-1-6-test
   (:require [clojure.test :refer [deftest is]]
             [sicp.chapter-1.part-1.book-1-1 :as b11]
-            [sicp.chapter-1.part_1.ex-1-06]))
+            [sicp.chapter-1.part-1.ex-1-06]))
 
 (deftest sqrt-iter-test
   ; Expected
@@ -11,4 +11,4 @@
 (deftest sqrt-iter-new-if-test
   ; Since the values (args in new-if) are calculated after substitution, we will have infinite execution.
   ; Arguments are not until whole statement is comprised only of primitive operations.
-  (is (= 6 (sicp.chapter-1.part_1.ex-1-06/sqrt-iter-new-if 6 36))))
+  (is (= 6 (sicp.chapter-1.part-1.ex-1-06/sqrt-iter-new-if 6 36))))

--- a/test/sicp/chapter_1/part_1/ex_1_7_test.clj
+++ b/test/sicp/chapter_1/part_1/ex_1_7_test.clj
@@ -1,7 +1,7 @@
-(ns sicp.chapter-1.part_1.ex-1-7-test
+(ns sicp.chapter-1.part-1.ex-1-7-test
   (:require [clojure.test :refer [deftest is]]
             [sicp.chapter-1.part-1.book-1-1 :as b11]
-            [sicp.chapter-1.part_1.ex-1-07 :refer [sqrt-iter-v2]]))
+            [sicp.chapter-1.part-1.ex-1-07 :refer [sqrt-iter-v2]]))
 
 (deftest sqrt-iter-test
   ; 1.0

--- a/test/sicp/chapter_1/part_1/ex_1_8_test.clj
+++ b/test/sicp/chapter_1/part_1/ex_1_8_test.clj
@@ -1,6 +1,6 @@
-(ns sicp.chapter-1.part_1.ex-1-8-test
+(ns sicp.chapter-1.part-1.ex-1-8-test
   (:require [clojure.test :refer [deftest is]]
-            [sicp.chapter-1.part_1.ex-1-08 :refer [cube-root-iter]]))
+            [sicp.chapter-1.part-1.ex-1-08 :refer [cube-root-iter]]))
 
 (deftest cube-root-iter-test
   ; 1.0

--- a/test/sicp/chapter_1/part_2/ex_1_10_test.clj
+++ b/test/sicp/chapter_1/part_2/ex_1_10_test.clj
@@ -1,6 +1,6 @@
-(ns sicp.chapter-1.part_2.ex-1-10-test
+(ns sicp.chapter-1.part-2.ex-1-10-test
   (:require [clojure.test :refer [deftest is]]
-            [sicp.chapter-1.part_2.ex-1-10 :refer [A f g h k]]))
+            [sicp.chapter-1.part-2.ex-1-10 :refer [A f g h k]]))
 
 (deftest A-test
   (is (= 1024 (A 1 10)))

--- a/test/sicp/chapter_1/part_2/ex_1_11_test.clj
+++ b/test/sicp/chapter_1/part_2/ex_1_11_test.clj
@@ -1,6 +1,6 @@
-(ns sicp.chapter-1.part_2.ex-1-11-test
+(ns sicp.chapter-1.part-2.ex-1-11-test
   (:require [clojure.test :refer [deftest is]]
-            [sicp.chapter-1.part_2.ex-1-11 :refer [f f-v2]]))
+            [sicp.chapter-1.part-2.ex-1-11 :refer [f f-v2]]))
 
 (deftest f-test
   ; ~ O(3^n)

--- a/test/sicp/chapter_1/part_2/ex_1_12_test.clj
+++ b/test/sicp/chapter_1/part_2/ex_1_12_test.clj
@@ -1,6 +1,6 @@
-(ns sicp.chapter-1.part_2.ex-1-12-test
+(ns sicp.chapter-1.part-2.ex-1-12-test
   (:require [clojure.test :refer [deftest is]]
-            [sicp.chapter-1.part_2.ex-1-12 :refer [pascal]]))
+            [sicp.chapter-1.part-2.ex-1-12 :refer [pascal]]))
 
 (deftest pascal-test
   (is (= 1 (pascal 1 1)))

--- a/test/sicp/chapter_1/part_2/ex_1_14_test.clj
+++ b/test/sicp/chapter_1/part_2/ex_1_14_test.clj
@@ -1,6 +1,6 @@
-(ns sicp.chapter-1.part_2.ex-1-14-test
+(ns sicp.chapter-1.part-2.ex-1-14-test
   (:require [clojure.test :refer [deftest is]]
-            [sicp.chapter-1.part_2.ex-1-14 :refer [money-change]]))
+            [sicp.chapter-1.part-2.ex-1-14 :refer [money-change]]))
 
 (deftest count-change-test
   (is (= 1 (money-change 1)))

--- a/test/sicp/chapter_1/part_2/ex_1_15_test.clj
+++ b/test/sicp/chapter_1/part_2/ex_1_15_test.clj
@@ -1,6 +1,6 @@
-(ns sicp.chapter-1.part_2.ex_1_15-test
+(ns sicp.chapter-1.part-2.ex-1-15-test
   (:require [clojure.test :refer [deftest is]]
-            [sicp.chapter-1.part_2.ex_1_15 :refer [sine]]))
+            [sicp.chapter-1.part-2.ex_1_15 :refer [sine]]))
 
 (deftest sine-test
   (is (= -0.39980345741334 (sine 12.15))))                   ; 5 times, O(log3(n))

--- a/test/sicp/chapter_1/part_2/ex_1_15_test.clj
+++ b/test/sicp/chapter_1/part_2/ex_1_15_test.clj
@@ -1,6 +1,6 @@
 (ns sicp.chapter-1.part-2.ex-1-15-test
   (:require [clojure.test :refer [deftest is]]
-            [sicp.chapter-1.part-2.ex_1_15 :refer [sine]]))
+            [sicp.chapter-1.part-2.ex-1-15 :refer [sine]]))
 
 (deftest sine-test
   (is (= -0.39980345741334 (sine 12.15))))                   ; 5 times, O(log3(n))

--- a/test/sicp/chapter_1/part_2/ex_1_16_test.clj
+++ b/test/sicp/chapter_1/part_2/ex_1_16_test.clj
@@ -1,6 +1,6 @@
-(ns sicp.chapter-1.part_2.ex-1-16-test
+(ns sicp.chapter-1.part-2.ex-1-16-test
   (:require [clojure.test :refer [deftest is]]
-            [sicp.chapter-1.part_2.ex-1-16 :refer [expt]]))
+            [sicp.chapter-1.part-2.ex-1-16 :refer [expt]]))
 
 (deftest expt-test
   (is (= 1 (expt 1 2)))

--- a/test/sicp/chapter_1/part_2/ex_1_17_test.clj
+++ b/test/sicp/chapter_1/part_2/ex_1_17_test.clj
@@ -1,6 +1,6 @@
-(ns sicp.chapter-1.part_2.ex-1-17-test
+(ns sicp.chapter-1.part-2.ex-1-17-test
   (:require [clojure.test :refer [deftest is]]
-            [sicp.chapter-1.part_2.ex-1-17 :refer [multi multi-fast]]))
+            [sicp.chapter-1.part-2.ex-1-17 :refer [multi multi-fast]]))
 
 (deftest multi-test
   (is (= 2 (multi 1 2)))                                    ; "Elapsed time: 2.383128 msecs"

--- a/test/sicp/chapter_1/part_2/ex_1_18_test.clj
+++ b/test/sicp/chapter_1/part_2/ex_1_18_test.clj
@@ -1,6 +1,6 @@
-(ns sicp.chapter-1.part_2.ex-1-18-test
+(ns sicp.chapter-1.part-2.ex-1-18-test
   (:require [clojure.test :refer [deftest is]]
-            [sicp.chapter-1.part_2.ex-1-18 :refer [mult]]))
+            [sicp.chapter-1.part-2.ex-1-18 :refer [mult]]))
 
 (deftest mult-test
   (is (= 0 (mult 0 19))))

--- a/test/sicp/chapter_1/part_2/ex_1_19_test.clj
+++ b/test/sicp/chapter_1/part_2/ex_1_19_test.clj
@@ -1,6 +1,6 @@
-(ns sicp.chapter-1.part_2.ex-1-19-test
+(ns sicp.chapter-1.part-2.ex-1-19-test
   (:require [clojure.test :refer [deftest is]]
-            [sicp.chapter-1.part_2.ex-1-19 :refer [fib fib-v2]]))
+            [sicp.chapter-1.part-2.ex-1-19 :refer [fib fib-v2]]))
 
 (deftest fib-test
   (is (= 1 (fib 1)))

--- a/test/sicp/chapter_1/part_2/ex_1_20_test.clj
+++ b/test/sicp/chapter_1/part_2/ex_1_20_test.clj
@@ -1,6 +1,6 @@
-(ns sicp.chapter-1.part_2.ex-1-20-test
+(ns sicp.chapter-1.part-2.ex-1-20-test
   (:require [clojure.test :refer [deftest is]]
-            [sicp.chapter-1.part_2.ex-1-20 :refer [gcd]]))
+            [sicp.chapter-1.part-2.ex-1-20 :refer [gcd]]))
 
 (deftest gcd-test
   (is (= 2 (gcd 206 40))))                                   ; 4 times

--- a/test/sicp/chapter_1/part_2/ex_1_21_test.clj
+++ b/test/sicp/chapter_1/part_2/ex_1_21_test.clj
@@ -1,6 +1,6 @@
-(ns sicp.chapter-1.part_2.ex-1-21-test
+(ns sicp.chapter-1.part-2.ex-1-21-test
   (:require [clojure.test :refer [deftest is]]
-            [sicp.chapter-1.part_2.ex-1-21 :refer [smallest-divisor]]))
+            [sicp.chapter-1.part-2.ex-1-21 :refer [smallest-divisor]]))
 
 (deftest smallest-divisor-test
   (is (= 199 (smallest-divisor 199)))

--- a/test/sicp/chapter_1/part_2/ex_1_22_test.clj
+++ b/test/sicp/chapter_1/part_2/ex_1_22_test.clj
@@ -1,6 +1,6 @@
-(ns sicp.chapter-1.part_2.ex-1-22-test
+(ns sicp.chapter-1.part-2.ex-1-22-test
   (:require [clojure.test :refer [deftest is]]
-            [sicp.chapter-1.part_2.ex-1-22 :refer [find-primes]]))
+            [sicp.chapter-1.part-2.ex-1-22 :refer [find-primes]]))
 
 (deftest find-primes-test
   (is (= 5 (find-primes 1 5 false))))                       ; Change arguments and see the output

--- a/test/sicp/chapter_1/part_2/ex_1_23_test.clj
+++ b/test/sicp/chapter_1/part_2/ex_1_23_test.clj
@@ -1,6 +1,6 @@
-(ns sicp.chapter-1.part_2.ex-1-23-test
+(ns sicp.chapter-1.part-2.ex-1-23-test
   (:require [clojure.test :refer [deftest is]]
-            [sicp.chapter-1.part_2.ex-1-23 :refer [find-divisor next-odd prime? smallest-divisor]]))
+            [sicp.chapter-1.part-2.ex-1-23 :refer [find-divisor next-odd prime? smallest-divisor]]))
 
 (deftest next-odd-test
   (is (= 3 (next-odd 1)))

--- a/test/sicp/chapter_1/part_2/ex_1_24_test.clj
+++ b/test/sicp/chapter_1/part_2/ex_1_24_test.clj
@@ -1,6 +1,6 @@
-(ns sicp.chapter-1.part_2.ex-1-24-test
+(ns sicp.chapter-1.part-2.ex-1-24-test
   (:require [clojure.test :refer [deftest is]]
-            [sicp.chapter-1.part_2.ex-1-24 :refer [fast-prime? fermat-test]]))
+            [sicp.chapter-1.part-2.ex-1-24 :refer [fast-prime? fermat-test]]))
 
 (deftest fast-prime?-test
   (is (= false (fast-prime? 100 100))))

--- a/test/sicp/chapter_1/part_2/ex_1_9_test.clj
+++ b/test/sicp/chapter_1/part_2/ex_1_9_test.clj
@@ -1,6 +1,6 @@
-(ns sicp.chapter-1.part_2.ex-1-9-test
+(ns sicp.chapter-1.part-2.ex-1-9-test
   (:require [clojure.test :refer [deftest is]]
-            [sicp.chapter-1.part_2.ex-1-09 :refer [plus plus-v2]]))
+            [sicp.chapter-1.part-2.ex-1-09 :refer [plus plus-v2]]))
 
 (deftest plus-test
   (is (= 3 (plus 1 2))))


### PR DESCRIPTION
Standardized namespace naming convention across all SICP exercises by replacing underscores with hyphens. This maintains consistency with the Clojure naming guidelines and improves the readability of the code.