### PR TITLE
Add exercise 2.70

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Solving exercises from SICP with Clojure
 
 [![Clojure CI](https://github.com/SmetDenis/Clojure-Sicp/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/SmetDenis/Clojure-Sicp/actions/workflows/main.yml)
-![Progress](https://progress-bar.dev/115/?scale=356&title=Solved&width=500&suffix=)
+![Progress](https://progress-bar.dev/116/?scale=356&title=Solved&width=500&suffix=)
 
 SICP (Structure and Interpretation of Computer Programs) is the book of Harold Abelson and Gerald
 Jay Sussman on basics of computer science and software engineering.
@@ -42,7 +42,7 @@ Jay Sussman on basics of computer science and software engineering.
 
 ### Chapter 2 - Building Abstractions with Data
 
-![Progress](https://progress-bar.dev/69/?scale=97&title=Solved&width=500&suffix=)
+![Progress](https://progress-bar.dev/70/?scale=97&title=Solved&width=500&suffix=)
 
 * [2.1](https://sarabander.github.io/sicp/html/Chapter-2.xhtml#Chapter-2) Introduction to Data Abstraction - [Code in book](src/sicp/chapter_2/part_1/book_2_1.clj)
   * [2.1.1](https://sarabander.github.io/sicp/html/2_002e1.xhtml#g_t2_002e1_002e1) Example: Arithmetic Operations for Rational Numbers - [2.1](src/sicp/chapter_2/part_1/ex_2_01.clj)
@@ -58,7 +58,7 @@ Jay Sussman on basics of computer science and software engineering.
   * [2.3.1](https://sarabander.github.io/sicp/html/2_002e3.xhtml#g_t2_002e3_002e1) Quotation - [2.53](src/sicp/chapter_2/part_3/ex_2_53.clj), [2.54](src/sicp/chapter_2/part_3/ex_2_54.clj), [2.55](src/sicp/chapter_2/part_3/ex_2_55.clj)
   * [2.3.2](https://sarabander.github.io/sicp/html/2_002e3.xhtml#g_t2_002e3_002e2) Example: Symbolic Differentiation - [2.56](src/sicp/chapter_2/part_3/ex_2_56.clj), [2.57](src/sicp/chapter_2/part_3/ex_2_57.clj), [2.58](src/sicp/chapter_2/part_3/ex_2_58.clj)
   * [2.3.3](https://sarabander.github.io/sicp/html/2_002e3.xhtml#g_t2_002e3_002e3) Example: Representing Sets - [2.59](src/sicp/chapter_2/part_3/ex_2_59.clj), [2.60](src/sicp/chapter_2/part_3/ex_2_60.clj), [2.61](src/sicp/chapter_2/part_3/ex_2_61.clj), [2.62](src/sicp/chapter_2/part_3/ex_2_62.clj), [2.63](src/sicp/chapter_2/part_3/ex_2_63.clj), [2.64](src/sicp/chapter_2/part_3/ex_2_64.clj), [2.65](src/sicp/chapter_2/part_3/ex_2_65.clj), [2.66](src/sicp/chapter_2/part_3/ex_2_66.clj)
-  * [2.3.4](https://sarabander.github.io/sicp/html/2_002e3.xhtml#g_t2_002e3_002e4) Example: Huffman Encoding Trees - [2.67](src/sicp/chapter_2/part_3/ex_2_67.clj), [2.68](src/sicp/chapter_2/part_3/ex_2_68.clj), [2.69](src/sicp/chapter_2/part_3/ex_2_69.clj)
+  * [2.3.4](https://sarabander.github.io/sicp/html/2_002e3.xhtml#g_t2_002e3_002e4) Example: Huffman Encoding Trees - [2.67](src/sicp/chapter_2/part_3/ex_2_67.clj), [2.68](src/sicp/chapter_2/part_3/ex_2_68.clj), [2.69](src/sicp/chapter_2/part_3/ex_2_69.clj), [2.70](src/sicp/chapter_2/part_3/ex_2_70.clj)
 * 2.4 Multiple Representations for Abstract Data
   * 2.4.1 Representations for Complex Numbers
   * 2.4.2 Tagged data

--- a/src/sicp/chapter_2/part_3/ex_2_68.clj
+++ b/src/sicp/chapter_2/part_3/ex_2_68.clj
@@ -28,7 +28,7 @@
                     right-branch      (b23/right-branch-h tree)
                     symbols-in-branch (b23/symbols tree)]
                 (if (b23/element-of-set? symbol symbols-in-branch)
-                  (if (b23/element-of-set? symbol left-branch)
+                  (if (b23/element-of-set? symbol (b23/symbols left-branch))
                     (cons 0 (encode-symbol symbol left-branch))
                     (cons 1 (encode-symbol symbol right-branch)))
                   (throw (Exception. (str "Symbol not found in tree " symbol)))))))

--- a/src/sicp/chapter_2/part_3/ex_2_70.clj
+++ b/src/sicp/chapter_2/part_3/ex_2_70.clj
@@ -1,0 +1,41 @@
+(ns sicp.chapter-2.part-3.ex-2-70)
+
+; Exercise 2.70
+;
+; The following eight-symbol alphabet with associated relative frequencies was designed
+; to efficiently encode the lyrics of 1950s rock songs. (Note that the “symbols” of an “alphabet”
+; need not be individual letters.)
+;
+; A    2    NA  16
+; BOOM 1    SHA  3
+; GET  2    YIP  9
+; JOB  2    WAH  1
+;
+; Use generate-huffman-tree (Exercise 2.69) to generate a corresponding Huffman tree, and use
+; encode (Exercise 2.68) to encode the following message:
+;
+; Get a job
+; Sha na na na na na na na na
+;
+; Get a job
+; Sha na na na na na na na na
+;
+; Wah yip yip yip yip
+; yip yip yip yip yip
+; Sha boom
+;
+; How many bits are required for the encoding? What is the smallest number of bits that would be
+; needed to encode this song if we used a fixed-length code for the eight-symbol alphabet?
+
+(def abc '((:a 2) (:na 16)
+           (:boom 1) (:Sha 3)
+           (:Get 2) (:yip 9)
+           (:job 2) (:Wah 1)))
+
+(def song '(:Get :a :job
+             :Sha :na :na :na :na :na :na :na :na
+             :Get :a :job
+             :Sha :na :na :na :na :na :na :na :na
+             :Wah :yip :yip :yip :yip
+             :yip :yip :yip :yip :yip
+             :Sha :boom))

--- a/test/sicp/chapter_2/part_3/book_2_3_test.clj
+++ b/test/sicp/chapter_2/part_3/book_2_3_test.clj
@@ -52,6 +52,11 @@
 
 (deftest element-of-set?-test
   (is (= true (element-of-set? 1 '(1 2 3))))
+  (is (= true (element-of-set? 1 '[1 2 3])))
+  (is (= true (element-of-set? :a '(:a :b))))
+  (is (= true (element-of-set? :a '[:a :b])))
+  (is (= true (element-of-set? :b '[:a :b :c :d])))
+  (is (= true (element-of-set? :c '[:a :b :c :d])))
   (is (= false (element-of-set? 1 '(2 3))))
   (is (= false (element-of-set? 1 '())))
   (is (= false (element-of-set? nil '()))))
@@ -70,6 +75,8 @@
 (deftest element-of-set-optimized?-test
   (is (= true (element-of-set-sorted? 1 '(1 2 3))))
   (is (= false (element-of-set-sorted? 1 '(2 3))))
+  (is (= true (element-of-set-sorted? :a '(:a :b))))
+  (is (= true (element-of-set-sorted? :a '[:a :b])))
   (is (= false (element-of-set-sorted? 1 '())))
   (is (= false (element-of-set-sorted? nil '())))
   (is (= true (element-of-set-sorted? 100 (range 10000000))))) ; faster than element-of-set?

--- a/test/sicp/chapter_2/part_3/ex_2_68_test.clj
+++ b/test/sicp/chapter_2/part_3/ex_2_68_test.clj
@@ -30,4 +30,4 @@
             1 0                                             ; B
             1 1 1                                           ; C
             0)                                              ; A
-         (encode '(:A :D :A :B :B :C :A) b23/huffman-tree))))
+         (encode b23/huffman-message-encoded b23/huffman-tree))))

--- a/test/sicp/chapter_2/part_3/ex_2_70_test.clj
+++ b/test/sicp/chapter_2/part_3/ex_2_70_test.clj
@@ -1,0 +1,57 @@
+(ns sicp.chapter-2.part-3.ex-2-70-test
+  (:require [clojure.test :refer [deftest is]]
+            [sicp.chapter-2.part-3.ex-2-68 :as ex-2-68]
+            [sicp.chapter-2.part-3.ex-2-69 :as ex-2-69]
+            [sicp.chapter-2.part-3.ex-2-70 :refer [abc song]]))
+
+(deftest abc-test
+  (is (= '[[:leaf :na 16]
+           [[:leaf :yip 9]
+            [[[:leaf :a 2]
+              [[:leaf :Wah 1]
+               [:leaf :boom 1]
+               (:Wah :boom) 2]
+              (:a :Wah :boom) 4]
+             [[:leaf :Sha 3]
+              [[:leaf :job 2]
+               [:leaf :Get 2]
+               (:job :Get) 4]
+              (:Sha :job :Get) 7]
+             (:a :Wah :boom :Sha :job :Get) 11]
+            (:yip :a :Wah :boom :Sha :job :Get) 20]
+           (:na :yip :a :Wah :boom :Sha :job :Get) 36]
+         (ex-2-69/generate-huffman-tree abc))))
+
+(deftest symbols-test
+  (is (= '(0)
+         (ex-2-68/encode-symbol :na (ex-2-69/generate-huffman-tree abc))))
+  (is (= '(1 0)
+         (ex-2-68/encode-symbol :yip (ex-2-69/generate-huffman-tree abc))))
+  (is (= '(1 1 1 0)
+         (ex-2-68/encode-symbol :Sha (ex-2-69/generate-huffman-tree abc))))
+  (is (= '(1 1 0 0)
+         (ex-2-68/encode-symbol :a (ex-2-69/generate-huffman-tree abc))))
+  (is (= '(1 1 1 1 1)
+         (ex-2-68/encode-symbol :Get (ex-2-69/generate-huffman-tree abc))))
+  (is (= '(1 1 1 1 0)
+         (ex-2-68/encode-symbol :job (ex-2-69/generate-huffman-tree abc))))
+  (is (= '(1 1 0 1 0)
+         (ex-2-68/encode-symbol :Wah (ex-2-69/generate-huffman-tree abc))))
+  (is (= '(1 1 0 1 1)
+         (ex-2-68/encode-symbol :boom (ex-2-69/generate-huffman-tree abc)))))
+
+(deftest song-encode-test
+  (is (= '(1 1 1 1 1 1 1 0 0 1 1 1 1 0 1 1 1
+            0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 0
+            0 1 1 1 1 0 1 1 1 0 0 0 0 0 0 0 0
+            0 1 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1
+            0 1 0 1 0 1 0 1 1 1 0 1 1 0 1 1)
+         (ex-2-68/encode song (ex-2-69/generate-huffman-tree abc))))
+  ; (~11 bytes) 84 bits insted of 124 charates OR 992 bits!
+  ; 992/84 = ~11.8 times smaller
+  ; 1 - 84/992 = ~91.5% safe memory space (without tree)
+  (is (= 84 (count (ex-2-68/encode song (ex-2-69/generate-huffman-tree abc)))))
+  ; If we were to use a fixed-length encoding on that rock song
+  ; We would need 3 bits (8 = 2^3) per symbol.
+  ; PS. 8 is number of unique words in the tree
+  (is (= 108 (* 3 (count song)))))


### PR DESCRIPTION
Expanded testing for `element-of-set?` and `element-of-set-sorted?` functions. They are providing better edge case coverage. Corrected an error in the `encode-symbol` function within ex_2_68.clj. Also, added new files `ex_2_70.clj` and its corresponding test file to handle encoding of specific rock songs.