### PR TITLE
Add experimental unit tests job to GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,27 +29,6 @@ jobs:
       - name: 🧪 Unit tests
         run: lein test
 
-  tests-experimental:
-    name: Unit tests - experimental
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Prepare Java
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'zulu'
-          java-version: '8'
-
-      - name: Install Clojure tools
-        uses: DeLaGuardo/setup-clojure@12.4
-        with:
-          cli: 'latest'
-          bb: 'latest'
-
-      - name: 🧪 Unit tests (bb + test-runner)
-        run: bb test
 
   linters:
     name: Linters
@@ -78,6 +57,7 @@ jobs:
       - name: 👍 Kondo
         run: bb lint:kondo
 
+
   codestyle:
     name: Codestyle
     runs-on: ubuntu-latest
@@ -100,3 +80,26 @@ jobs:
 
       - name: 👍 cljfmt
         run: bb lint:check
+
+
+  experimental:
+    name: Experimental
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Prepare Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+
+      - name: Install Clojure tools
+        uses: DeLaGuardo/setup-clojure@12.4
+        with:
+          cli: 'latest'
+          bb: 'latest'
+
+      - name: 🧪 Unit tests (bb + test-runner)
+        run: bb test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   tests:
-    name: Unit tests
+    name: Tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -26,7 +26,7 @@ jobs:
           cli: 'latest'
           lein: 'latest'
 
-      - name: Unit tests
+      - name: 🧪 Unit tests
         run: lein test
 
   tests-experimental:
@@ -48,7 +48,7 @@ jobs:
           cli: 'latest'
           bb: 'latest'
 
-      - name: Unit tests (bb + test-runner)
+      - name: 🧪 Unit tests (bb + test-runner)
         run: bb test
 
   linters:
@@ -72,10 +72,10 @@ jobs:
           bb: 'latest'
           clj-kondo: 'latest'
 
-      - name: Eastwood
+      - name: 👍 Eastwood
         run: bb lint:eastwood
 
-      - name: Kondo
+      - name: 👍 Kondo
         run: bb lint:kondo
 
   codestyle:
@@ -98,5 +98,5 @@ jobs:
           bb: 'latest'
           cljfmt: 'latest'
 
-      - name: cljfmt
+      - name: 👍 cljfmt
         run: bb lint:check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,10 +25,28 @@ jobs:
         with:
           cli: 'latest'
           lein: 'latest'
-          bb: 'latest'
 
       - name: Unit tests
         run: lein test
+
+  tests-experimental:
+    name: Unit tests (experimental)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Prepare Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+
+      - name: Install Clojure tools
+        uses: DeLaGuardo/setup-clojure@12.4
+        with:
+          cli: 'latest'
+          bb: 'latest'
 
       - name: Unit tests (bb + test-runner)
         run: bb test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
         run: lein test
 
   tests-experimental:
-    name: Unit tests (experimental)
+    name: Unit tests - experimental
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
The updated GitHub Actions workflow now includes a new job for running experimental unit tests. This job utilizes an Ubuntu environment and Clojure tools to perform tests. This change improves the comprehensiveness of our testing process by separating conventional and experimental test runs.