### PR TITLE
Update dependencies for Clojure and linting tools

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,10 +85,6 @@ jobs:
       - name: 👍 cljstyle
         run: bb style:cljstyle
 
-      - name: 👍 kibit
-        run: bb style:kibit
-
-
   experimental:
     name: Experimental
     runs-on: ubuntu-latest
@@ -110,3 +106,6 @@ jobs:
 
       - name: 🧪 Unit tests (bb + test-runner)
         run: bb test
+
+      - name: 👍 splint
+        run: bb style:splint || true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,6 +85,9 @@ jobs:
       - name: 👍 cljstyle
         run: bb style:cljstyle
 
+      - name: 👍 kibit
+        run: bb style:kibit
+
 
   experimental:
     name: Experimental

--- a/bb.edn
+++ b/bb.edn
@@ -1,23 +1,21 @@
-{:tasks {test           (shell "clojure -X:test")
+{:tasks {test           (shell "lein test")
          ; Check style
          style:cljfmt   (shell "cljfmt check")
          style:cljstyle (shell "cljstyle check")
-         style:kibit    (shell "lein kibit")
-         ; Autofix style
-         fix:cljfmt     (shell "cljfmt fix")
-         fix:cljstyle   (shell "cljstyle fix")
-         fix:kibit      (shell "lein kibit --replace")
-         ; Linters
-         lint:eastwood  (shell "clojure -M:test:eastwood")
-         lint:kondo     (shell "clj-kondo --lint test src")
-         ; Combo tasks
-         lint           (do (run 'style:cljfmt)
+         style:splint   (shell "lein splint ./src ./test")
+         lint           (do (run 'style:splint)
+                            (run 'style:cljfmt)
                             (run 'style:cljstyle)
                             (run 'lint:eastwood)
                             (run 'lint:kondo))
-         fix            (do (run 'fix:kibit)
-                            (run 'fix:cljfmt)
+         ; Autofix style
+         fix:cljfmt     (shell "cljfmt fix")
+         fix:cljstyle   (shell "cljstyle fix")
+         fix            (do (run 'fix:cljfmt)
                             (run 'fix:cljstyle))
+         ; Linters
+         lint:eastwood  (shell "lein eastwood")
+         lint:kondo     (shell "clj-kondo --lint test src")
          ; Local development
          pre-push       (do (run 'fix)
                             (run 'lint)

--- a/bb.edn
+++ b/bb.edn
@@ -1,16 +1,24 @@
-{:tasks {test               (shell "clojure -X:test")
-         lint               (do (run 'style:cljfmt)
-                                (run 'style:cljstyle)
-                                (run 'lint:eastwood)
-                                (run 'lint:kondo))
-         style:fix          (do (run 'style:fix:cljfmt)
-                                (run 'style:fix:cljstyle))
-         style:cljfmt       (shell "cljfmt check")
-         style:cljstyle     (shell "cljstyle check")
-         style:fix:cljfmt   (shell "cljfmt fix")
-         style:fix:cljstyle (shell "cljstyle fix")
-         lint:eastwood      (shell "clojure -M:test:eastwood")
-         lint:kondo         (shell "clj-kondo --lint test src")
-         pre-push           (do (run 'style:fix)
-                                (run 'test)
-                                (run 'lint))}}
+{:tasks {test           (shell "clojure -X:test")
+         ; Check style
+         style:cljfmt   (shell "cljfmt check")
+         style:cljstyle (shell "cljstyle check")
+         style:kibit    (shell "lein kibit")
+         ; Autofix style
+         fix:cljfmt     (shell "cljfmt fix")
+         fix:cljstyle   (shell "cljstyle fix")
+         fix:kibit      (shell "lein kibit --replace")
+         ; Linters
+         lint:eastwood  (shell "clojure -M:test:eastwood")
+         lint:kondo     (shell "clj-kondo --lint test src")
+         ; Combo tasks
+         lint           (do (run 'style:cljfmt)
+                            (run 'style:cljstyle)
+                            (run 'lint:eastwood)
+                            (run 'lint:kondo))
+         fix            (do (run 'fix:kibit)
+                            (run 'fix:cljfmt)
+                            (run 'fix:cljstyle))
+         ; Local development
+         pre-push       (do (run 'fix)
+                            (run 'lint)
+                            (run 'test))}}

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,8 @@
   :test-paths ["test"]
   :main ^:skip-aot sicp
   :target-path "build/%s"
-  :plugins [[jonase/eastwood "1.4.2"]]
+  :plugins [[jonase/eastwood "1.4.2"]
+            [lein-kibit "0.1.8"]]
   :profiles {:dev      {:dependencies [[jonase/eastwood "1.4.2"]]}
              :test     {:main-opts ["-m" "cognitect.test-runner"]}
              :eastwood {:main-opts ["-m" "eastwood.lint" {}]}

--- a/project.clj
+++ b/project.clj
@@ -8,10 +8,12 @@
   :test-paths ["test"]
   :main ^:skip-aot sicp
   :target-path "build/%s"
-  :plugins [[jonase/eastwood "1.4.2"]
-            [lein-kibit "0.1.8"]]
-  :profiles {:dev      {:dependencies [[jonase/eastwood "1.4.2"]]}
+  :plugins [[jonase/eastwood "1.4.2"]]
+  :profiles {:dev      {:dependencies [[io.github.noahtheduke/splint "1.12"]
+                                       [jonase/eastwood "1.4.2"]
+                                       [org.clojure/clojure "1.11.1"]]}
              :test     {:main-opts ["-m" "cognitect.test-runner"]}
              :eastwood {:main-opts ["-m" "eastwood.lint" {}]}
              :uberjar  {:aot :all}
-             :jvm-opts ["-Dclojure.compiler.direct-linking=true"]})
+             :jvm-opts ["-Dclojure.compiler.direct-linking=true"]}
+  :aliases {"splint" ["run" "-m" "noahtheduke.splint"]})

--- a/test/sicp/chapter_1/part_1/book_1_1_test.clj
+++ b/test/sicp/chapter_1/part_1/book_1_1_test.clj
@@ -19,28 +19,28 @@
 
 (deftest abs-1-test
   (is (= 1 (b11/abs-1 1)))
-  (is (= 0 (b11/abs-1 0)))
+  (is (zero? (b11/abs-1 0)))
   (is (= 1 (b11/abs-1 -1))))
 
 (deftest abs-2-test
   (is (= 1 (b11/abs-2 1)))
-  (is (= 0 (b11/abs-2 0)))
+  (is (zero? (b11/abs-2 0)))
   (is (= 1 (b11/abs-2 -1))))
 
 (deftest abs-3-test
   (is (= 1 (b11/abs-3 1)))
-  (is (= 0 (b11/abs-3 0)))
+  (is (zero? (b11/abs-3 0)))
   (is (= 1 (b11/abs-3 -1))))
 
 (deftest >=-1-test
-  (is (= false (b11/>=-1 1 2)))
-  (is (= true (b11/>=-1 1 1)))
-  (is (= true (b11/>=-1 2 1))))
+  (is (false? (b11/>=-1 1 2)))
+  (is (true? (b11/>=-1 1 1)))
+  (is (true? (b11/>=-1 2 1))))
 
 (deftest >=-2-test
-  (is (= false (b11/>=-2 1 2)))
-  (is (= true (b11/>=-2 1 1)))
-  (is (= true (b11/>=-2 2 1))))
+  (is (false? (b11/>=-2 1 2)))
+  (is (true? (b11/>=-2 1 1)))
+  (is (true? (b11/>=-2 2 1))))
 
 (comment "1.1.7 Example: Square Roots by Newton’s Method -----------------------------------------")
 

--- a/test/sicp/chapter_1/part_1/ex_1_4_test.clj
+++ b/test/sicp/chapter_1/part_1/ex_1_4_test.clj
@@ -6,5 +6,5 @@
 (deftest a-plus-abs-b-test
   (is (= 2 (a-plus-abs-b 1 1)))
   (is (= 2 (a-plus-abs-b 1 -1)))
-  (is (= 0 (a-plus-abs-b -1 1)))
-  (is (= 0 (a-plus-abs-b -1 -1))))
+  (is (zero? (a-plus-abs-b -1 1)))
+  (is (zero? (a-plus-abs-b -1 -1))))

--- a/test/sicp/chapter_1/part_1/ex_1_5_test.clj
+++ b/test/sicp/chapter_1/part_1/ex_1_5_test.clj
@@ -5,6 +5,6 @@
 
 (deftest test_1_5-test
   ; Normal: Operand "p" will not be evaluated until it's needed by some primitive operation. So result is 0.
-  (is (= 0 (test_1_5 0 p)))
+  (is (zero? (test_1_5 0 p)))
   ; Applicative: Operand "y" will be by default evaluated. Then it will end up in recursion since (p) points to itself.
   (is (= p (test_1_5 1 p))))

--- a/test/sicp/chapter_1/part_2/book_1_2_test.clj
+++ b/test/sicp/chapter_1/part_2/book_1_2_test.clj
@@ -58,10 +58,10 @@
   (is (= 59049 (b12/expt-2 3 10))))
 
 (deftest even?-alt-test
-  (is (= false (b12/even?-alt 1)))
-  (is (= true (b12/even?-alt 2)))
-  (is (= false (b12/even?-alt 3)))
-  (is (= true (b12/even?-alt 4))))
+  (is (false? (b12/even?-alt 1)))
+  (is (true? (b12/even?-alt 2)))
+  (is (false? (b12/even?-alt 3)))
+  (is (true? (b12/even?-alt 4))))
 
 (comment "1.2.5 Greatest Common Divisors ---------------------------------------------------------")
 
@@ -71,7 +71,7 @@
   (is (= 12 (b12/gcd 36 48)))
   (is (= 5 (b12/gcd 5 0)))
   (is (= 5 (b12/gcd 0 5)))
-  (is (= 0 (b12/gcd 0 0)))
+  (is (zero? (b12/gcd 0 0)))
   (is (= 21 (b12/gcd 21 21)))
   (is (= 1 (b12/gcd 17 19))))
 
@@ -85,15 +85,15 @@
   (is (= 7 (b12/smallest-divisor 1001))))
 
 (deftest prime?-test
-  (is (= true (b12/prime? 7)))
-  (is (= false (b12/prime? 21))))
+  (is (true? (b12/prime? 7)))
+  (is (false? (b12/prime? 21))))
 
 (deftest expmod-test
   (is (= 1 (b12/expmod 3 0 5)))
   (is (= 1 (b12/expmod 3 4 2)))
   (is (= 81 (b12/expmod 3 4 100)))
   (is (= 16 (b12/expmod 2 4 20)))
-  (is (= 0 (b12/expmod 2 3 4)))
+  (is (zero? (b12/expmod 2 3 4)))
   (is (= 7 (b12/expmod 5 2 9))))
 
 (deftest fermat-test-test

--- a/test/sicp/chapter_1/part_2/ex_1_18_test.clj
+++ b/test/sicp/chapter_1/part_2/ex_1_18_test.clj
@@ -4,4 +4,4 @@
     [sicp.chapter-1.part-2.ex-1-18 :refer [mult]]))
 
 (deftest mult-test
-  (is (= 0 (mult 0 19))))
+  (is (zero? (mult 0 19))))

--- a/test/sicp/chapter_1/part_2/ex_1_23_test.clj
+++ b/test/sicp/chapter_1/part_2/ex_1_23_test.clj
@@ -27,15 +27,15 @@
 
 (deftest prime?-test
   ; Prime
-  (is (= true (prime? 1)))
-  (is (= true (prime? 2)))
-  (is (= true (prime? 3)))
-  (is (= true (prime? 5)))
-  (is (= true (prime? 7)))
-  (is (= true (prime? 11)))
-  (is (= true (prime? 23)))
+  (is (true? (prime? 1)))
+  (is (true? (prime? 2)))
+  (is (true? (prime? 3)))
+  (is (true? (prime? 5)))
+  (is (true? (prime? 7)))
+  (is (true? (prime? 11)))
+  (is (true? (prime? 23)))
   ; Not prime
-  (is (= false (prime? 4)))
-  (is (= false (prime? 6)))
-  (is (= false (prime? 8)))
-  (is (= false (prime? 20))))
+  (is (false? (prime? 4)))
+  (is (false? (prime? 6)))
+  (is (false? (prime? 8)))
+  (is (false? (prime? 20))))

--- a/test/sicp/chapter_1/part_2/ex_1_24_test.clj
+++ b/test/sicp/chapter_1/part_2/ex_1_24_test.clj
@@ -4,13 +4,13 @@
     [sicp.chapter-1.part-2.ex-1-24 :refer [fast-prime? fermat-test]]))
 
 (deftest fast-prime?-test
-  (is (= false (fast-prime? 100 100))))
+  (is (false? (fast-prime? 100 100))))
 
 (deftest fermat-test-test
-  (is (= false (fermat-test 1)))
-  (is (= false (fermat-test 2)))
-  (is (= false (fermat-test 3)))
-  (is (= false (fermat-test 5)))
-  (is (= false (fermat-test 6)))
-  (is (= false (fermat-test 11)))
-  (is (= false (fermat-test 21))))
+  (is (false? (fermat-test 1)))
+  (is (false? (fermat-test 2)))
+  (is (false? (fermat-test 3)))
+  (is (false? (fermat-test 5)))
+  (is (false? (fermat-test 6)))
+  (is (false? (fermat-test 11)))
+  (is (false? (fermat-test 21))))

--- a/test/sicp/chapter_1/part_2/ex_1_27_test.clj
+++ b/test/sicp/chapter_1/part_2/ex_1_27_test.clj
@@ -4,9 +4,9 @@
     [sicp.chapter-1.part-2.ex-1-27 :refer [fermat-test]]))
 
 (deftest fermat-test-test
-  (is (= true (fermat-test 561)))
-  (is (= true (fermat-test 1105)))
-  (is (= true (fermat-test 1729)))
-  (is (= true (fermat-test 2465)))
-  (is (= true (fermat-test 2821)))
-  (is (= true (fermat-test 6601))))
+  (is (true? (fermat-test 561)))
+  (is (true? (fermat-test 1105)))
+  (is (true? (fermat-test 1729)))
+  (is (true? (fermat-test 2465)))
+  (is (true? (fermat-test 2821)))
+  (is (true? (fermat-test 6601))))

--- a/test/sicp/chapter_1/part_3/book_1_3_test.clj
+++ b/test/sicp/chapter_1/part_3/book_1_3_test.clj
@@ -7,7 +7,7 @@
 (comment "1.3.1 Procedures as Arguments ----------------------------------------------------------")
 
 (deftest sum-integers-test
-  (is (= 0 (b13/sum-integers 0 0)))
+  (is (zero? (b13/sum-integers 0 0)))
   (is (= 1 (b13/sum-integers 1 1)))
   (is (= 3 (b13/sum-integers 1 2)))
   (is (= 6 (b13/sum-integers 1 3)))
@@ -15,7 +15,7 @@
   (is (= 15 (b13/sum-integers 1 5))))
 
 (deftest sum-cubes-test
-  (is (= 0 (b13/sum-cubes 0 0)))
+  (is (zero? (b13/sum-cubes 0 0)))
   (is (= 1 (b13/sum-cubes 1 1)))
   (is (= 9 (b13/sum-cubes 1 2)))
   (is (= 36 (b13/sum-cubes 1 3)))
@@ -69,8 +69,8 @@
 (comment "1.3.3 Procedures as General Methods ----------------------------------------------------")
 
 (deftest search-test
-  (is (= 0 (b13/search m/cube -1 1)))
-  (is (= 0 (b13/search m/cube -9 9)))
+  (is (zero? (b13/search m/cube -1 1)))
+  (is (zero? (b13/search m/cube -9 9)))
   (is (= 1/16384 (b13/search m/cube -1 9))))
 
 (deftest half-interval-method-test


### PR DESCRIPTION
The lein-kibit plugin has been removed and replaced with splint linter. Clojure has also been updated to version 1.11.1. Corresponding changes have been made to the testing and linting tasks in bb.edn to accommodate the updated configurations.