### PR TITLE
Add splint to linting process and update tasks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -107,3 +107,6 @@ jobs:
 
       - name: 🧪 Unit tests (bb + test-runner)
         run: bb test
+
+      - name: 🧪 splint
+        run: bb style:splint || true

--- a/bb.edn
+++ b/bb.edn
@@ -1,4 +1,4 @@
-{:tasks {test           (shell "lein test")
+{:tasks {test           (shell "clojure -X:test")
          ; Check style
          style:cljfmt   (shell "cljfmt check")
          style:cljstyle (shell "cljstyle check")
@@ -14,7 +14,7 @@
          fix            (do (run 'fix:cljfmt)
                             (run 'fix:cljstyle))
          ; Linters
-         lint:eastwood  (shell "lein eastwood")
+         lint:eastwood  (shell "clojure -M:test:eastwood")
          lint:kondo     (shell "clj-kondo --lint test src")
          ; Local development
          pre-push       (do (run 'fix)

--- a/bb.edn
+++ b/bb.edn
@@ -1,16 +1,22 @@
-{:tasks {test               (shell "clojure -X:test")
-         lint               (do (run 'style:cljfmt)
-                                (run 'style:cljstyle)
-                                (run 'lint:eastwood)
-                                (run 'lint:kondo))
-         style:fix          (do (run 'style:fix:cljfmt)
-                                (run 'style:fix:cljstyle))
-         style:cljfmt       (shell "cljfmt check")
-         style:cljstyle     (shell "cljstyle check")
-         style:fix:cljfmt   (shell "cljfmt fix")
-         style:fix:cljstyle (shell "cljstyle fix")
-         lint:eastwood      (shell "clojure -M:test:eastwood")
-         lint:kondo         (shell "clj-kondo --lint test src")
-         pre-push           (do (run 'style:fix)
-                                (run 'test)
-                                (run 'lint))}}
+{:tasks {test           (shell "lein test")
+         ; Check style
+         style:cljfmt   (shell "cljfmt check")
+         style:cljstyle (shell "cljstyle check")
+         style:splint   (shell "lein splint ./src ./test")
+         lint           (do (run 'style:splint)
+                            (run 'style:cljfmt)
+                            (run 'style:cljstyle)
+                            (run 'lint:eastwood)
+                            (run 'lint:kondo))
+         ; Autofix style
+         fix:cljfmt     (shell "cljfmt fix")
+         fix:cljstyle   (shell "cljstyle fix")
+         fix            (do (run 'fix:cljfmt)
+                            (run 'fix:cljstyle))
+         ; Linters
+         lint:eastwood  (shell "lein eastwood")
+         lint:kondo     (shell "clj-kondo --lint test src")
+         ; Local development
+         pre-push       (do (run 'fix)
+                            (run 'lint)
+                            (run 'test))}}

--- a/project.clj
+++ b/project.clj
@@ -9,8 +9,10 @@
   :main ^:skip-aot sicp
   :target-path "build/%s"
   :plugins [[jonase/eastwood "1.4.2"]]
-  :profiles {:dev      {:dependencies [[jonase/eastwood "1.4.2"]]}
+  :profiles {:dev      {:dependencies [[org.clojure/clojure "1.11.1"]
+                                       [io.github.noahtheduke/splint "1.12"]]}
              :test     {:main-opts ["-m" "cognitect.test-runner"]}
              :eastwood {:main-opts ["-m" "eastwood.lint" {}]}
              :uberjar  {:aot :all}
-             :jvm-opts ["-Dclojure.compiler.direct-linking=true"]})
+             :jvm-opts ["-Dclojure.compiler.direct-linking=true"]}
+  :aliases {"splint" ["run" "-m" "noahtheduke.splint"]})

--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,6 @@
   :profiles {:dev      {:dependencies [[org.clojure/clojure "1.11.1"]
                                        [io.github.noahtheduke/splint "1.12"]]}
              :test     {:main-opts ["-m" "cognitect.test-runner"]}
-             :eastwood {:main-opts ["-m" "eastwood.lint" {}]}
              :uberjar  {:aot :all}
              :jvm-opts ["-Dclojure.compiler.direct-linking=true"]}
   :aliases {"splint" ["run" "-m" "noahtheduke.splint"]})


### PR DESCRIPTION
Splint has been integrated into the linting process. Changes were made in the Github workflows, project.clj and bb.edn files. Tasks for style checking, linting, and fixing have been reshuffled and updated accordingly.