### PR TITLE
Add caching for Leiningen dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Cache Leiningen dependencies
         uses: actions/cache@v2
         with:
-          path: ~/.m2
+          path: ~/.lein
           key: ${{ runner.os }}-lein-${{ hashFiles('**/project.clj') }}
           restore-keys: ${{ runner.os }}-lein-
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Cache Leiningen dependencies
         uses: actions/cache@v2
         with:
-          path: ~/.lein
+          path: ~/.m2
           key: ${{ runner.os }}-lein-${{ hashFiles('**/project.clj') }}
           restore-keys: ${{ runner.os }}-lein-
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,13 @@ jobs:
           cli: 'latest'
           lein: 'latest'
 
+      - name: Cache Leiningen dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-lein-${{ hashFiles('**/project.clj') }}
+          restore-keys: ${{ runner.os }}-lein-
+
       - name: 🧪 Unit tests
         run: lein test
 
@@ -47,6 +54,13 @@ jobs:
         with:
           cli: 'latest'
           lein: 'latest'
+
+      - name: Cache Leiningen dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-lein-${{ hashFiles('**/project.clj') }}
+          restore-keys: ${{ runner.os }}-lein-
 
       - name: 🧪 Generate coverage report
         run: lein cloverage --lcov
@@ -81,6 +95,13 @@ jobs:
           bb: 'latest'
           clj-kondo: 'latest'
 
+      - name: Cache Leiningen dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-lein-${{ hashFiles('**/project.clj') }}
+          restore-keys: ${{ runner.os }}-lein-
+
       - name: 👍 Eastwood
         run: bb lint:eastwood
 
@@ -109,6 +130,13 @@ jobs:
           cljfmt: 'latest'
           cljstyle: 'latest'
 
+      - name: Cache Leiningen dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-lein-${{ hashFiles('**/project.clj') }}
+          restore-keys: ${{ runner.os }}-lein-
+
       - name: 👍 cljfmt
         run: bb style:cljfmt
 
@@ -134,6 +162,13 @@ jobs:
         with:
           cli: 'latest'
           bb: 'latest'
+
+      - name: Cache Leiningen dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-lein-${{ hashFiles('**/project.clj') }}
+          restore-keys: ${{ runner.os }}-lein-
 
       - name: 🧪 Unit tests (bb + test-runner)
         run: bb test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
         run: lein test
 
   tests-coverage:
-    name: Test Coverge
+    name: Tests - Coverge
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -65,7 +65,7 @@ jobs:
       - name: 🧪 Generate coverage report
         run: lein cloverage --lcov
 
-      - name: 🧪 Coveralls
+      - name: Coveralls
         uses: coverallsapp/github-action@master
         with:
           path-to-lcov: ./target/coverage/lcov.info


### PR DESCRIPTION
Introduced caching for Leiningen dependencies on GitHub actions workflow. This changes are made in order to improve build times and efficiency. The cache is now based on the hash of 'project.clj', ensuring up-to-date dependencies.